### PR TITLE
refactor(repository): switch to projection-based paging methods

### DIFF
--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Extensions/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ public static class ServiceCollectionExtensions
     /// <returns>Returns the configured service collection.</returns>
     public static IServiceCollection AddMappings(this IServiceCollection services)
     {
-        services.AddSingleton<IItemMapper, ItemMapper>();
+        services.AddSingleton<IItemMapper, ItemMapperService>();
         // register other mappers here
 
         return services;

--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Handlers/GetItemsHandler.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Handlers/GetItemsHandler.cs
@@ -15,16 +15,21 @@ public class GetItemsHandler(IItemRepository itemRepository, IItemMapper mapper)
     {
         if (query.PagingParameters != null)
         {
-            var totalCount = await _itemRepository.GetCountAsync(cancellationToken);
-            var items = await _itemRepository.GetPagedAsync(query.PagingParameters.PageNumber, query.PagingParameters.PageSize, cancellationToken);
-            var itemDtos = _mapper.ToDto(items);
+            var (itemDtos, totalCount) = await _itemRepository.GetPagedProjectionAsync(
+                _mapper.ProjectToDto,
+                query.PagingParameters.PageNumber,
+                query.PagingParameters.PageSize,
+                cancellationToken);
+                
             return new PagedResult<ItemDto>(itemDtos, totalCount, query.PagingParameters.PageNumber, query.PagingParameters.PageSize);
         }
         else
         {
-            var items = await _itemRepository.GetAllAsync();
-            var itemDtos = _mapper.ToDto(items);
-            return new PagedResult<ItemDto>(itemDtos.ToArray(), items.Count());
+            var itemDtos = await _itemRepository.GetAllProjectionAsync(
+                _mapper.ProjectToDto,
+                cancellationToken);
+                
+            return new PagedResult<ItemDto>(itemDtos, itemDtos.Count());
         }
     }
 }

--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Mappings/IItemMapper.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Mappings/IItemMapper.cs
@@ -1,5 +1,3 @@
-
-
 namespace MyService.Application.Item.Mappings;
 
 public interface IItemMapper
@@ -7,4 +5,5 @@ public interface IItemMapper
     Dtos.ItemDto ToDto(Domain.Entities.Item item);
     Domain.Entities.Item ToEntity(Dtos.CreateItemDto dto);
     IEnumerable<Dtos.ItemDto> ToDto(IEnumerable<Domain.Entities.Item> items);
+    IQueryable<Dtos.ItemDto> ProjectToDto(IQueryable<Domain.Entities.Item> items);
 }

--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Mappings/ItemMapper.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Mappings/ItemMapper.cs
@@ -3,17 +3,18 @@ using Riok.Mapperly.Abstractions;
 namespace MyService.Application.Item.Mappings;
 
 [Mapper]
-public partial class ItemMapper : IItemMapper
+public static partial class ItemMapper
 {
-    public partial Dtos.ItemDto ToDto(Domain.Entities.Item item);
-
+    public static partial Dtos.ItemDto ToDto(Domain.Entities.Item item);
 
     [MapperIgnoreTarget(nameof(Domain.Entities.Item.Id))]
     [MapperIgnoreTarget(nameof(Domain.Entities.Item.CreatedAt))]
     [MapperIgnoreTarget(nameof(Domain.Entities.Item.UpdatedAt))]
-    public partial Domain.Entities.Item ToEntity(Dtos.CreateItemDto dto);
+    public static partial Domain.Entities.Item ToEntity(Dtos.CreateItemDto dto);
 
-    public partial IEnumerable<Dtos.ItemDto> ToDto(IEnumerable<Domain.Entities.Item> items);
+    public static partial IEnumerable<Dtos.ItemDto> ToDto(IEnumerable<Domain.Entities.Item> items);
+
+    public static partial IQueryable<Dtos.ItemDto> ProjectToDto(IQueryable<Domain.Entities.Item> items);   
 }
 
 

--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Mappings/ItemMapperService.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Application/Item/Mappings/ItemMapperService.cs
@@ -1,0 +1,13 @@
+namespace MyService.Application.Item.Mappings;
+
+// Wrapper class for dependency injection compatibility
+public class ItemMapperService : IItemMapper
+{
+    public Dtos.ItemDto ToDto(Domain.Entities.Item item) => ItemMapper.ToDto(item);
+
+    public Domain.Entities.Item ToEntity(Dtos.CreateItemDto dto) => ItemMapper.ToEntity(dto);
+
+    public IEnumerable<Dtos.ItemDto> ToDto(IEnumerable<Domain.Entities.Item> items) => ItemMapper.ToDto(items);
+
+    public IQueryable<Dtos.ItemDto> ProjectToDto(IQueryable<Domain.Entities.Item> items) => ItemMapper.ProjectToDto(items);
+}

--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Domain/Interfaces/IItemRepository.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Domain/Interfaces/IItemRepository.cs
@@ -13,7 +13,7 @@ public interface IItemRepository
 
     /// <summary>
     /// Gets all items without pagination. Use with caution for large datasets.
-    /// Consider using GetPagedAsync or projection methods for better performance.
+    /// Consider using projection methods for better performance.
     /// </summary>
     Task<IEnumerable<Item>> GetAllAsync(CancellationToken cancellationToken = default);
 

--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Domain/Interfaces/IItemRepository.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Domain/Interfaces/IItemRepository.cs
@@ -4,12 +4,69 @@ namespace MyService.Domain.Interfaces;
 
 public interface IItemRepository
 {
+    /// <summary>
+    /// Gets an item by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the item.</param>
+    /// <returns>A task representing the asynchronous operation, containing the item if found, or null otherwise.</returns>
     Task<Item?> GetByIdAsync(int id);
-    Task<int> GetCountAsync(CancellationToken cancellationToken = default);
-    Task<IEnumerable<Item>> GetPagedAsync(int pageNumber, int pageSize, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all items without pagination. Use with caution for large datasets.
+    /// Consider using GetPagedAsync or projection methods for better performance.
+    /// </summary>
     Task<IEnumerable<Item>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a paged list of projected items using the provided projection function.
+    /// This is more efficient than fetching entities and then mapping them.
+    /// </summary>
+    /// <typeparam name="TProjection">The type to project to.</typeparam>
+    /// <param name="projection">A function that defines the projection from IQueryable<Item> to IQueryable<TProjection>.</param>
+    /// <param name="pageNumber">The page number (1-based).</param>
+    /// <param name="pageSize">The number of items per page.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A tuple containing the projected items and the total count.</returns>
+    Task<(IEnumerable<TProjection> Items, int TotalCount)> GetPagedProjectionAsync<TProjection>(
+        Func<IQueryable<Item>, IQueryable<TProjection>> projection,
+        int pageNumber, 
+        int pageSize, 
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all projected items using the provided projection function.
+    /// This is more efficient than fetching entities and then mapping them.
+    /// </summary>
+    /// <typeparam name="TProjection">The type to project to.</typeparam>
+    /// <param name="projection">A function that defines the projection from IQueryable<Item> to IQueryable<TProjection>.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A list of projected items.</returns>
+    Task<IEnumerable<TProjection>> GetAllProjectionAsync<TProjection>(
+        Func<IQueryable<Item>, IQueryable<TProjection>> projection,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a new item to the repository.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task AddAsync(Item item, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing item in the repository.
+    /// </summary>
+    /// <param name="item">The item to update.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task UpdateAsync(Item item, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes an item from the repository.
+    /// </summary>
+    /// <param name="item">The item to delete.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task DeleteAsync(Item item, CancellationToken cancellationToken = default);
 
 }

--- a/templates/MicroserviceTemplate.Aspire/src/MyService.Infrastructure/Repositories/ItemRepository.cs
+++ b/templates/MicroserviceTemplate.Aspire/src/MyService.Infrastructure/Repositories/ItemRepository.cs
@@ -7,22 +7,45 @@ namespace MyService.Infrastructure.Repositories
     public class ItemRepository : IItemRepository
     {
         private readonly Data.AppDbContext _dbContext;
-
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemRepository"/> class.
+        /// </summary>
+        /// <param name="dbContext">The database context to be used by the repository.</param>
         public ItemRepository(Data.AppDbContext dbContext)
         {
             _dbContext = dbContext;
         }
 
+        /// <summary>
+        /// Gets an item by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the item.</param>
+        /// <returns>A task representing the asynchronous operation, containing the item if found, or null otherwise.</returns>
         public async Task<Item?> GetByIdAsync(int id)
         {
             return await _dbContext.Items.FindAsync(id);
         }
 
+        /// <summary>
+        /// Gets all items without pagination. Use with caution for large datasets.
+        /// Consider using projection methods for better performance.
+        /// </summary>
         public async Task<IEnumerable<Item>> GetAllAsync(CancellationToken cancellationToken = default)
         {
             return await _dbContext.Items.ToListAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Gets a paged list of projected items using the provided projection function.
+        /// This is more efficient than fetching entities and then mapping them.
+        /// </summary>
+        /// <typeparam name="TProjection">The type to project to.</typeparam>
+        /// <param name="projection">A function that defines the projection from IQueryable<Item> to IQueryable<TProjection>.</param>
+        /// <param name="pageNumber">The page number (1-based).</param>
+        /// <param name="pageSize">The number of items per page.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A tuple containing the projected items and the total count.</returns>
         public async Task<(IEnumerable<TProjection> Items, int TotalCount)> GetPagedProjectionAsync<TProjection>(
         Func<IQueryable<Item>, IQueryable<TProjection>> projection,
         int pageNumber,
@@ -31,16 +54,24 @@ namespace MyService.Infrastructure.Repositories
         {
             var query = _dbContext.Items.AsQueryable();
             var totalCount = await query.CountAsync(cancellationToken);
-            
+
             var projectedQuery = projection(query);
             var items = await projectedQuery
                 .Skip((pageNumber - 1) * pageSize)
                 .Take(pageSize)
                 .ToListAsync(cancellationToken);
-                
+
             return (items, totalCount);
         }
 
+        /// <summary>
+        /// Gets all projected items using the provided projection function.
+        /// This is more efficient than fetching entities and then mapping them.
+        /// </summary>
+        /// <typeparam name="TProjection">The type to project to.</typeparam>
+        /// <param name="projection">A function that defines the projection from IQueryable<Item> to IQueryable<TProjection>.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A list of projected items.</returns>
         public async Task<IEnumerable<TProjection>> GetAllProjectionAsync<TProjection>(
             Func<IQueryable<Item>, IQueryable<TProjection>> projection,
             CancellationToken cancellationToken = default)
@@ -50,18 +81,36 @@ namespace MyService.Infrastructure.Repositories
             return await projectedQuery.ToListAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Adds a new item to the repository.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         public async Task AddAsync(Item item, CancellationToken cancellationToken = default)
         {
             await _dbContext.Items.AddAsync(item, cancellationToken);
             await _dbContext.SaveChangesAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Updates an existing item in the repository.
+        /// </summary>
+        /// <param name="item">The item to update.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         public async Task UpdateAsync(Item item, CancellationToken cancellationToken = default)
         {
             _dbContext.Items.Update(item);
             await _dbContext.SaveChangesAsync(cancellationToken);
         }
 
+        /// <summary>
+        /// Deletes an item from the repository.
+        /// </summary>
+        /// <param name="item">The item to delete.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         public async Task DeleteAsync(Item item, CancellationToken cancellationToken = default)
         {
             if (item != null)


### PR DESCRIPTION
## Refactor Repository Paging to Use Projection-Based Methods

Closes #9

### 📋 Overview

This pull request refactors the repository paging logic to exclusively use projection-based methods (`GetPagedProjectionAsync` and `GetAllProjectionAsync`) instead of the legacy `GetPagedAsync`. The changes leverage Mapperly's IQueryable projection feature for more efficient and flexible data access.

### 🚀 Key Changes

- ✅ Removed `GetPagedAsync` from `IItemRepository` and its implementation.
- ✅ Updated all usages in the application to rely on `GetPagedProjectionAsync` and `GetAllProjectionAsync`.
- ✅ Refactored tests (including `ItemEndpointTests`) to mock and verify the new projection-based methods.
- ✅ Ensured the Application layer remains free of direct Entity Framework Core dependencies.
- ✅ Added documentation and comments to highlight the preferred usage pattern.
- ✅ Added a warning comment to `GetAllAsync` regarding potential performance issues with large datasets.

### 🎯 Motivation

- **Performance**: Only the required fields are fetched from the database, reducing overhead.
- **Consistency**: Standardizes paging and projection across the codebase.
- **Maintainability**: Simplifies the repository interface and its usage.
- **Best Practices**: Aligns with modern .NET and Mapperly recommendations.
